### PR TITLE
Add option to replace json, rather than merge it

### DIFF
--- a/bin/stronghold-cli
+++ b/bin/stronghold-cli
@@ -121,7 +121,7 @@ opts = GetoptLong.new(
   [ '--next', '-n', GetoptLong::OPTIONAL_ARGUMENT ],
   [ '--set', '-s', GetoptLong::REQUIRED_ARGUMENT ],
   [ '--set-json', '-j', GetoptLong::OPTIONAL_ARGUMENT ],
-  [ '--replace-json', '-R', GetoptLong::OPTIONAL_ARGUMENT ],
+  [ '--replace-json', '-J', GetoptLong::OPTIONAL_ARGUMENT ],
   [ '--app', '-a', GetoptLong::REQUIRED_ARGUMENT ],
   [ '--history', '-h', GetoptLong::OPTIONAL_ARGUMENT ],
   [ '--path', '-p', GetoptLong::REQUIRED_ARGUMENT ],

--- a/bin/stronghold-cli
+++ b/bin/stronghold-cli
@@ -121,6 +121,7 @@ opts = GetoptLong.new(
   [ '--next', '-n', GetoptLong::OPTIONAL_ARGUMENT ],
   [ '--set', '-s', GetoptLong::REQUIRED_ARGUMENT ],
   [ '--set-json', '-j', GetoptLong::OPTIONAL_ARGUMENT ],
+  [ '--replace-json', '-R', GetoptLong::OPTIONAL_ARGUMENT ],
   [ '--app', '-a', GetoptLong::REQUIRED_ARGUMENT ],
   [ '--history', '-h', GetoptLong::OPTIONAL_ARGUMENT ],
   [ '--path', '-p', GetoptLong::REQUIRED_ARGUMENT ],
@@ -205,6 +206,15 @@ opts.each do |opt, arg|
         comment: "At level #{$path} set json"
       )
     end
+  when '--replace-json'
+    mode_ify(opt)
+    json = JSON.load($stdin)
+    client.head.update(
+      path: $path,
+      author: "command-line on #{Socket.gethostname}, USER=#{ENV['USER']}",
+      data: json,
+      comment: "At level #{$path} set json"
+    )
   when '--get'
     mode_ify(opt)
     puts format(extract(valid_tree(), data_path(arg)))
@@ -240,8 +250,12 @@ elsif $mode == nil
   puts "  Set value of data path, creating hashes as we go. Use --force to overwrite"
   puts
   puts "  --set-json <stdin>"
-  puts "  Set value of data path. If you have a file then you can pipe like:"
+  puts "  Merge with value at data path. If you have a file then you can pipe like:"
   puts "  $ cat file.json | stronghold-cli --path /path/ --set-json"
+  puts
+  puts "  --replace-json <stdin>"
+  puts "  Replace value at data path. If you have a file then you can pipe like:"
+  puts "  $ cat file.json | stronghold-cli --path /path/ --replace-json"
   puts
   puts "  --env /data/path:PATHDATA ... -- runnable"
   puts "  Get data from stronghold head and put in environment variable, and run runnable"


### PR DESCRIPTION
[Stronghold](https://github.com/pusher/stronghold) doesn't have any documented APIs for deleting keys or paths.  In [stronghold-ui](https://github.com/pusher/stronghold-ui) you can achieve the same effect by doing the following: to delete a key, you can remove the key from the JSON for that path and save. To remove a path entirely, you can delete all the keys (so that the JSON is `{}`) and saving will remove the path. This works because updates replace the entire JSON structure at a path.

However in the stronghold-cli, the `--set-json` option **merges** the new JSON object with the old JSON object. This means it isn't possible to delete keys or to delete whole paths.

This PR adds a `--replace-json` option, which replaces the JSON at a path rather than merging the keys. This makes it possible to delete a path by replacing the JSON with `{}`:

```bash
echo "{}" | stronghold-cli --path /test/path --replace-json
```

While this does also make it possible to also delete individual keys, it would require the user of this CLI to provide the full JSON with the individual keys removed. The CLI could make the process simpler by giving an option to delete individual keys and that could be future work.